### PR TITLE
Reposition MLKFS site + procedural halftone hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# MLKFS — Remote Post-Production Studio 🎬🎧
+# MLKFS — Audio-Visual, Software & Creative 🎬🎧💻
 
-**MLKFS LLC** is a remote finishing studio based in California.  
-We bring the craft of post-production — in both image and sound — to projects worldwide.  
+**MLKFS LLC** is a California-based company working across audio-visual, software, and creative fields.  
+We build and apply technology — in image, sound, and software — for projects worldwide.  
 
 Our scope covers:  
 🎞️ Video Editing · 🎨 Color Grading · 🔊 Sound Design  

--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -1,0 +1,198 @@
+---
+// Procedural halftone "reel": the word MLKFS is rendered as living print dots
+// (black/blue/red/green) that grow and shrink. No video file — drawn in real
+// time on a <canvas>, so it weighs ~0 KB, loops forever, and stays crisp at
+// any resolution. Falls back to plain text when JS is off or reduced-motion.
+const word = "MLKFS";
+---
+
+<div class="hero-reel" data-word={word}>
+  <canvas class="hero-reel__canvas" aria-hidden="true"></canvas>
+  <h1 class="sr-only">{word}</h1>
+  <noscript>
+    <span class="hero-reel__fallback">{word}</span>
+  </noscript>
+</div>
+
+<style>
+  .hero-reel {
+    position: relative;
+    width: 100%;
+    /* scales with viewport but stays bounded */
+    height: clamp(120px, 24vw, 260px);
+  }
+  .hero-reel__canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+  .hero-reel__fallback {
+    display: block;
+    text-align: center;
+    font-weight: 800;
+    font-size: clamp(3rem, 16vw, 9rem);
+    letter-spacing: -0.02em;
+    line-height: 1;
+  }
+</style>
+
+<script>
+  type RGB = [number, number, number];
+
+  function initHeroReel(root: HTMLElement) {
+    const canvas = root.querySelector<HTMLCanvasElement>(".hero-reel__canvas");
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const word = root.dataset.word || "MLKFS";
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    // Print-channel palette: black, blue, red, green.
+    const palette: RGB[] = [
+      [17, 17, 17],
+      [0, 71, 255],
+      [255, 45, 45],
+      [0, 177, 64],
+    ];
+
+    type Dot = {
+      x: number;
+      y: number;
+      cov: number; // 0..1 coverage from the text mask
+      phase: number; // per-dot animation offset
+      color: RGB;
+    };
+
+    let dots: Dot[] = [];
+    let maxR = 6;
+    let dpr = 1;
+    let raf = 0;
+    let visible = true;
+
+    // Sample the rendered word into a coverage grid, then place one dot per cell.
+    function build() {
+      const cssW = root.clientWidth;
+      const cssH = root.clientHeight;
+      if (cssW === 0 || cssH === 0) return;
+
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+
+      // Offscreen mask of the word, sized to the device pixels.
+      const mask = document.createElement("canvas");
+      mask.width = canvas.width;
+      mask.height = canvas.height;
+      const mctx = mask.getContext("2d");
+      if (!mctx) return;
+
+      mctx.fillStyle = "#000";
+      mctx.textAlign = "center";
+      mctx.textBaseline = "middle";
+
+      // Grow the font until the word fills ~92% of the width.
+      let fontPx = canvas.height;
+      const targetW = canvas.width * 0.92;
+      const font = (px: number) =>
+        `800 ${px}px ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif`;
+      mctx.font = font(fontPx);
+      let measured = mctx.measureText(word).width;
+      fontPx = Math.max(8, (fontPx * targetW) / measured);
+      mctx.font = font(fontPx);
+      mctx.clearRect(0, 0, mask.width, mask.height);
+      mctx.fillText(word, mask.width / 2, mask.height / 2);
+
+      const data = mctx.getImageData(0, 0, mask.width, mask.height).data;
+
+      // Dot grid spacing in device pixels (≈8 CSS px).
+      const gap = Math.max(6, Math.round(8 * dpr));
+      maxR = gap * 0.62;
+
+      dots = [];
+      for (let y = gap / 2; y < canvas.height; y += gap) {
+        for (let x = gap / 2; x < canvas.width; x += gap) {
+          const idx = (Math.floor(y) * mask.width + Math.floor(x)) * 4 + 3;
+          const cov = data[idx] / 255; // alpha = inside the letters
+          if (cov < 0.04) continue;
+          // Cluster colors with a low-frequency pattern + a little noise so it
+          // reads as misregistered print channels rather than random confetti.
+          const region =
+            Math.floor(x / (gap * 6)) + Math.floor(y / (gap * 6)) * 2;
+          const jitter = Math.floor((Math.sin(x * 12.9 + y * 78.2) + 1) * 1.7);
+          const color = palette[(region + jitter) % palette.length];
+          dots.push({
+            x,
+            y,
+            cov,
+            phase: (x + y) * 0.012,
+            color,
+          });
+        }
+      }
+    }
+
+    function draw(t: number) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      // Group draws by color to minimise fillStyle changes.
+      for (const c of palette) {
+        const path = new Path2D();
+        for (const d of dots) {
+          if (d.color !== c) continue;
+          // A traveling wave makes the dots breathe (grow/shrink) so the word
+          // feels like moving footage instead of a static screen.
+          const pulse = reduceMotion
+            ? 1
+            : 0.78 + 0.22 * Math.sin(t * 0.0019 + d.phase + d.x * 0.004);
+          const r = d.cov * maxR * pulse;
+          if (r <= 0.2) continue;
+          path.moveTo(d.x + r, d.y);
+          path.arc(d.x, d.y, r, 0, Math.PI * 2);
+        }
+        ctx.fillStyle = `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+        ctx.fill(path);
+      }
+    }
+
+    function loop(t: number) {
+      if (visible) draw(t);
+      raf = requestAnimationFrame(loop);
+    }
+
+    function start() {
+      cancelAnimationFrame(raf);
+      build();
+      if (reduceMotion) {
+        draw(0);
+        return;
+      }
+      raf = requestAnimationFrame(loop);
+    }
+
+    // Pause when the hero scrolls out of view (saves battery/CPU).
+    if ("IntersectionObserver" in window) {
+      const io = new IntersectionObserver(
+        (entries) => {
+          visible = entries[0]?.isIntersecting ?? true;
+        },
+        { threshold: 0 }
+      );
+      io.observe(root);
+    }
+
+    let resizeTimer = 0;
+    window.addEventListener("resize", () => {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(start, 150);
+    });
+
+    start();
+  }
+
+  document
+    .querySelectorAll<HTMLElement>(".hero-reel")
+    .forEach((el) => initHeroReel(el));
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,9 +4,9 @@ import Footer from "../components/Footer.astro";
 import "../styles/global.css";
 
 export interface Props { title?: string; description?: string }
-const { 
-  title = "MLKFS – Creative Post-Production Studio", 
-  description = "Remote post-production: editing, color, sound, YouTube management." 
+const {
+  title = "MLKFS – Audio-Visual, Software & Creative",
+  description = "MLKFS builds and applies technology across audio-visual, software, and creative work."
 } = Astro.props;
 ---
 <html lang="en" class="h-full bg-white text-black">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const title = "About – MLKFS";
-const description = "MLKFS is a California‑based remote post‑production studio.";
+const description = "MLKFS is a California‑based company working across audio‑visual, software, and creative fields.";
 ---
 
 <BaseLayout {title} {description}>
@@ -10,8 +10,8 @@ const description = "MLKFS is a California‑based remote post‑production stud
     <div class="mx-auto max-w-3xl text-center">
       <h1 class="text-4xl md:text-5xl font-bold leading-tight text-black">About</h1>
       <p class="mt-4 text-base text-gray-700 leading-relaxed">
-        MLKFS grew from music, photography and documentary roots into a finishing studio that delivers
-        editing, color and sound for global projects.
+        MLKFS grew from music, photography and documentary roots into a company that builds and applies
+        technology across audio‑visual, software, and creative work for global projects.
       </p>
       <p class="mt-5 text-base text-gray-600 leading-relaxed">
         Founded in California and led by <span class="font-medium text-black">Ege Batuhan Akgül</span>, we keep scopes simple

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,16 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import HeroReel from "../components/HeroReel.astro";
 
 const title = "MLKFS — Audio-visual, software & creative";
 const description = "MLKFS builds and applies technology across audio-visual, software, and creative work.";
 ---
 
 <BaseLayout {title} {description}>
-  <section class="container-xl pt-24 pb-12">
-    <div class="mx-auto text-center max-w-2xl">
-      <h1 class="text-4xl md:text-5xl font-bold leading-tight tracking-tight text-black">
-        MLKFS
-      </h1>
-      <p class="mt-3 text-lg md:text-xl text-gray-700 italic">
+  <section class="container-xl pt-20 pb-12">
+    <div class="mx-auto text-center max-w-3xl">
+      <HeroReel />
+      <p class="mt-4 text-lg md:text-xl text-gray-700 italic">
         Audio-visual · Software · Creative
       </p>
       <p class="mt-4 text-base text-gray-600">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 
-const title = "MLKFS - post-production and open-source tools";
-const description = "Post-production studio and open-source tools by MLKFS.";
+const title = "MLKFS — Audio-visual, software & creative";
+const description = "MLKFS builds and applies technology across audio-visual, software, and creative work.";
 ---
 
 <BaseLayout {title} {description}>
@@ -12,10 +12,10 @@ const description = "Post-production studio and open-source tools by MLKFS.";
         MLKFS
       </h1>
       <p class="mt-3 text-lg md:text-xl text-gray-700 italic">
-        Post-production studio · Open-source tools
+        Audio-visual · Software · Creative
       </p>
       <p class="mt-4 text-base text-gray-600">
-        Image, sound, delivery, and small open-source tools for real production work.
+        We build and apply technology across image, sound, and software — and ship the products that come out of it.
       </p>
       <div class="mt-7 flex flex-col items-center justify-center gap-3 sm:flex-row">
         <a href="/contact"
@@ -40,7 +40,7 @@ const description = "Post-production studio and open-source tools by MLKFS.";
     <div class="mx-auto max-w-3xl text-center">
       <h2 class="text-2xl md:text-3xl font-semibold text-black">What we do</h2>
       <p class="mt-3 text-base text-gray-600">
-        Editing, color, sound, and delivery in one focused workflow.
+        Technology-driven work across image, sound, delivery, and the software behind it.
       </p>
     </div>
 
@@ -77,9 +77,9 @@ const description = "Post-production studio and open-source tools by MLKFS.";
   <section class="container-xl py-12">
     <div class="mx-auto max-w-3xl border-y border-black/10 py-10 text-center">
       <p class="text-sm font-medium uppercase tracking-[0.18em] text-gray-500">Software</p>
-      <h2 class="mt-3 text-2xl md:text-3xl font-semibold text-black">Tools published in the open</h2>
+      <h2 class="mt-3 text-2xl md:text-3xl font-semibold text-black">Products we design and build</h2>
       <p class="mt-4 text-base text-gray-600 leading-relaxed">
-        Practical tools, readable source, and public project history on GitHub.
+        From open tools for everyday workflows to a closed-source AI service for universities and libraries.
       </p>
       <div class="mt-6">
         <a
@@ -106,7 +106,7 @@ const description = "Post-production studio and open-source tools by MLKFS.";
       </p>
 
       <p class="mt-5 text-base text-gray-500 leading-relaxed">
-        Based in California, built for remote collaboration, and shaped by practical production work.
+        Based in California, built for remote collaboration, and shaped by hands-on technical and creative work.
       </p>
     </div>
   </section>
@@ -143,11 +143,12 @@ const description = "Post-production studio and open-source tools by MLKFS.";
     <div class="max-w-2xl mx-auto text-center">
       <h2 class="text-2xl md:text-3xl font-semibold text-black">About</h2>
       <p class="mt-4 text-base text-gray-700 leading-relaxed">
-        MLKFS grew from music, photography, documentary work, and independent publishing.
+        MLKFS grew from music, photography, documentary work, and independent publishing into a company
+        spanning audio-visual, software, and creative work.
       </p>
       <p class="mt-5 text-base text-gray-600 leading-relaxed">
         Founded in California and led by <span class="font-medium text-black">Ege Batuhan Akgül</span>,
-        the studio works with the same care across commercial, personal, and experimental projects.
+        we work with the same care across commercial, personal, and experimental projects.
       </p>
     </div>
     

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -9,7 +9,7 @@ const description = "Editing, color grading, sound design & mix, YouTube channel
   <section class="container-xl pt-28 pb-24">
     <div class="mx-auto max-w-4xl text-center">
       <h1 class="text-4xl md:text-5xl font-bold leading-tight text-black">Services</h1>
-      <p class="mt-3 text-base text-gray-600">Clear scopes. Reliable delivery.</p>
+      <p class="mt-3 text-base text-gray-600">Audio-visual and creative work, delivered with clear scopes and reliable timelines.</p>
     </div>
 
     <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/pages/software.astro
+++ b/src/pages/software.astro
@@ -2,18 +2,18 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const title = "Software - MLKFS";
-const description = "Open-source tools published by MLKFS.";
+const description = "Software and products MLKFS builds — from open tools to a closed-source AI service for libraries.";
 ---
 
 <BaseLayout {title} {description}>
   <section class="container-xl pt-24 pb-10">
     <div class="mx-auto max-w-3xl text-center">
-      <p class="text-sm font-medium uppercase tracking-[0.18em] text-gray-500">Open source</p>
+      <p class="text-sm font-medium uppercase tracking-[0.18em] text-gray-500">Software</p>
       <h1 class="mt-3 text-4xl md:text-5xl font-bold leading-tight text-black">
-        Software by MLKFS
+        Software &amp; products we build
       </h1>
       <p class="mt-5 text-base md:text-lg text-gray-600 leading-relaxed">
-        Small tools for real workflows.
+        Open tools for everyday workflows and closed-source products built for scale.
       </p>
     </div>
   </section>
@@ -23,7 +23,7 @@ const description = "Open-source tools published by MLKFS.";
       <div class="p-6 md:p-8">
         <div class="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
           <div>
-            <p class="text-sm font-medium uppercase tracking-[0.16em] text-gray-500">macOS CLI</p>
+            <p class="text-sm font-medium uppercase tracking-[0.16em] text-gray-500">Open source · macOS CLI</p>
             <h2 class="mt-2 text-2xl font-semibold text-black">
               <a href="/software/batt-sail" class="hover:underline underline-offset-4">batt-sail</a>
             </h2>
@@ -67,24 +67,65 @@ const description = "Open-source tools published by MLKFS.";
     </div>
   </section>
 
+  <section class="container-xl pb-12">
+    <div class="mx-auto max-w-4xl border border-black/10 bg-gray-50">
+      <div class="p-6 md:p-8">
+        <div class="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p class="text-sm font-medium uppercase tracking-[0.16em] text-gray-500">Closed source · Service</p>
+            <h2 class="mt-2 text-2xl font-semibold text-black">
+              PDF → EPUB for libraries
+            </h2>
+            <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+              An AI service that converts thousands of PDFs — especially theses and dissertations — into clean,
+              reflowable EPUBs for universities and large libraries.
+            </p>
+          </div>
+          <div class="flex shrink-0 flex-wrap gap-3">
+            <a
+              href="/contact"
+              class="inline-flex items-center justify-center border border-black px-5 py-2 text-sm font-medium hover:bg-black hover:text-white transition"
+            >
+              Request access
+            </a>
+          </div>
+        </div>
+        <div class="mt-6 grid gap-4 border-t border-black/10 pt-6 md:grid-cols-3">
+          <div>
+            <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">Reach</p>
+            <p class="mt-2 text-sm text-gray-700">More citations and discoverability for digitized work.</p>
+          </div>
+          <div>
+            <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">Research</p>
+            <p class="mt-2 text-sm text-gray-700">Searchable, reflowable text that speeds up reading.</p>
+          </div>
+          <div>
+            <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">Space</p>
+            <p class="mt-2 text-sm text-gray-700">Digitize at scale and free up shelf space.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section class="container-xl pb-20">
     <div class="mx-auto grid max-w-4xl gap-6 md:grid-cols-3">
       <div class="border-t border-black/10 pt-5">
-        <h2 class="text-lg font-semibold text-black">Open</h2>
+        <h2 class="text-lg font-semibold text-black">Practical</h2>
         <p class="mt-2 text-sm text-gray-600 leading-relaxed">
-          Public source and project history.
+          Software built for real workflows and real scale.
         </p>
       </div>
       <div class="border-t border-black/10 pt-5">
         <h2 class="text-lg font-semibold text-black">Focused</h2>
         <p class="mt-2 text-sm text-gray-600 leading-relaxed">
-          Small tools with clear jobs.
+          Each product has a clear job and does it well.
         </p>
       </div>
       <div class="border-t border-black/10 pt-5">
-        <h2 class="text-lg font-semibold text-black">Installable</h2>
+        <h2 class="text-lg font-semibold text-black">Open or managed</h2>
         <p class="mt-2 text-sm text-gray-600 leading-relaxed">
-          Simple terminal-first setup.
+          Open tools to install, plus services we run for you.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Repositions the MLKFS site away from "post-production studio" toward a company working across **audio-visual, software, and creative** fields, and adds a real-time animated hero.

### Copy / framing
- Site-wide meta, hero, about, services, and README no longer lead with "post-production studio" or "open source".
- **Software section** reworked to show two offerings:
  - **batt-sail** — existing open-source macOS CLI (install command + links unchanged).
  - **PDF → EPUB for libraries** — new closed-source, AI-powered service for universities & large libraries (CTA → /contact).

### Hero animation
- New `src/components/HeroReel.astro`: the word "MLKFS" is rendered as living print dots (black/blue/red/green) that grow and shrink via a traveling wave, drawn in real time on a `<canvas>`.
- No video file — procedural, so it weighs ~0 KB, loops forever, and stays crisp at any resolution.
- Accessible hidden `<h1>`, no-JS text fallback, `prefers-reduced-motion` support, pauses when scrolled out of view.

## Verification
- `npm run build` passes (10 pages).
- No remaining post-production/studio framing in `src/` or `README.md`.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_