### PR TITLE
Hero: RGB matrix-rain wordmark, per-visit randomness

### DIFF
--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -76,26 +76,24 @@ const word = "MLKFS";
     const wave = reduceMotion ? 0.14 : 0.30; // smooth rippling component
     const flick = reduceMotion ? 0.10 : 0.40; // random twinkle component
     const moveScale = reduceMotion ? 0.5 : 1; // gentler drift in low-power mode
-    const hueSpeed = reduceMotion ? 8 : 20; // how fast the rainbow flows (°/s)
 
-    // Full-spectrum rainbow: dots take a hue from their position and the whole
-    // band drifts over time, so the word is made of every color (no black).
-    // We quantise hue + lightness into bins so a frame still issues a small,
-    // fixed number of fills.
-    const HUE_BINS = 36; // 10° steps
-    const LEVELS = 5; // shimmer (lightness) steps
-    const SAT = 85; // %
-    const L_MIN = 40; // trough lightness %
-    const L_MAX = 74; // crest lightness %
+    // Pure RGB sub-pixels: only red, green, blue — fully saturated, with each
+    // dot's brightness swinging the full 0..100% so cells fade to black and back
+    // (like a screen's sub-pixels). From a distance the three colors blend.
+    const COLORS: RGB[] = [
+      [255, 0, 0], // R
+      [0, 255, 0], // G
+      [0, 0, 255], // B
+    ];
+    const LEVELS = 8; // brightness steps from 0% to 100%
 
     type Dot = {
       x: number;
       y: number;
       cov: number; // 0..1 coverage from the text mask
-      hue: number; // base hue 0..360 (position-based)
+      ci: number; // color index: 0=R, 1=G, 2=B
       seed: number; // per-dot random phase (0..1) for twinkle/flicker
       tw: number; // twinkle speed multiplier (matrix-like flicker)
-      hj: number; // per-dot hue jitter in degrees
     };
 
     let dots: Dot[] = [];
@@ -155,13 +153,6 @@ const word = "MLKFS";
           const idx = (Math.floor(y) * mask.width + Math.floor(x)) * 4 + 3;
           const cov = data[idx] / 255; // alpha = inside the letters
           if (cov < 0.04) continue;
-          // Hue from position: a smooth left→right spectrum across the word,
-          // with a touch of vertical shift and noise so it shimmers like a
-          // rainbow on silk rather than clean vertical bands.
-          const sweep = (x / canvas.width) * 300; // most of the wheel L→R
-          const tilt = (y / canvas.height) * 60;
-          const noise = Math.sin(x * 0.05 + y * 0.08) * 12;
-          const hue = (sweep + tilt + noise + 360) % 360;
           // Per-dot randomness, re-seeded every visit: position hashes are
           // mixed with this session's SEED so the same pixel looks different
           // each load. Two machines opening together still differ.
@@ -173,10 +164,9 @@ const word = "MLKFS";
             x,
             y,
             cov,
-            hue: (hue + SEED * 360) % 360, // whole spectrum is rotated per visit
+            ci: Math.floor(rnd * 3) % 3, // random R/G/B per dot (per visit)
             seed: rnd,
             tw: 0.6 + rnd2 * 2.2, // each dot flickers at its own rate
-            hj: (rnd2 - 0.5) * 50, // ±25° hue scatter
           });
         }
       }
@@ -187,11 +177,10 @@ const word = "MLKFS";
       // Offset the clock per visit so the loop starts at a random phase.
       const time = (t + startOffset) * 0.001;
       const sway = maxR * 0.9 * moveScale; // how far dots drift (px)
-      const hueShift = (time * hueSpeed) % 360; // rainbow flows over time
 
-      // One Path2D per (hue bin, lightness level) so the frame issues a small,
+      // One Path2D per (color, brightness level) so the frame issues a small,
       // fixed number of fills no matter how many dots there are.
-      const paths: Path2D[][] = Array.from({ length: HUE_BINS }, () =>
+      const paths: Path2D[][] = COLORS.map(() =>
         Array.from({ length: LEVELS }, () => new Path2D())
       );
 
@@ -211,45 +200,42 @@ const word = "MLKFS";
         const dy = sway * Math.cos(ny - time * 0.6);
 
         // Per-dot random flicker (matrix): each dot pulses on its own phase and
-        // rate, layered on the smooth silk wave. Mostly bright with occasional
-        // near-zero dips so cells blink in and out.
+        // rate, layered on the smooth silk wave.
         const flickW = Math.sin(time * d.tw + d.seed * 6.283);
-        const mul = 1 - wave * 0.5 + wave * 0.5 * field + flick * flickW;
-        const r = d.cov * maxR * Math.max(0, mul);
+
+        // Brightness swings the full 0..1 (i.e. 0..100%): the wave + flicker
+        // drive each dot from black up to fully bright and back.
+        const liteT = Math.min(
+          1,
+          Math.max(
+            0,
+            0.5 + wave * 0.5 * field + flick * 0.5 * flickW + 0.18
+          )
+        );
+
+        // Radius stays roughly constant; the look is carried by brightness, so
+        // dark dots still hold the letter shape instead of disappearing.
+        const r = d.cov * maxR;
         if (r <= 0.2) continue;
 
-        // Lightness follows the combined motion so bright dots also pop in tone.
-        const liteT = (field * 0.5 + 0.5) * 0.5 + (flickW * 0.5 + 0.5) * 0.5;
-        const lvl = Math.min(
-          LEVELS - 1,
-          Math.max(0, Math.floor(liteT * LEVELS))
-        );
-        // Pull the hue toward the three screen primaries (R 0°, G 120°, B 240°)
-        // so the wordmark reads as RGB — fitting for work made for screens —
-        // while still passing through yellow/cyan/magenta in the transitions.
-        // d.hj scatters each dot's hue so colors don't form clean bands.
-        const u = ((((d.hue + d.hj + hueShift) % 360) + 360) % 360) / 360; // 0..1
-        const s = u * 3;
-        const seg = Math.floor(s);
-        const f = s - seg; // 0..1 within an R→G→B leg
-        const k = 2.4; // >1 widens the pure primaries, narrows the blends
-        const fp =
-          f < 0.5 ? 0.5 * Math.pow(2 * f, k) : 1 - 0.5 * Math.pow(2 - 2 * f, k);
-        const snapped = ((seg + fp) / 3) % 1; // back to 0..1
-        const hb = Math.floor(snapped * HUE_BINS) % HUE_BINS;
-        const p = paths[hb][lvl];
+        const lvl = Math.min(LEVELS - 1, Math.max(0, Math.floor(liteT * LEVELS)));
+        const p = paths[d.ci][lvl];
         const px = d.x + dx;
         const py = d.y + dy;
         p.moveTo(px + r, py);
         p.arc(px, py, r, 0, Math.PI * 2);
       }
 
-      for (let hb = 0; hb < HUE_BINS; hb++) {
-        const hue = (hb + 0.5) * (360 / HUE_BINS);
+      for (let ci = 0; ci < COLORS.length; ci++) {
+        const c = COLORS[ci];
         for (let l = 0; l < LEVELS; l++) {
-          const light = L_MIN + ((l + 0.5) / LEVELS) * (L_MAX - L_MIN);
-          ctx.fillStyle = `hsl(${hue.toFixed(0)}, ${SAT}%, ${light.toFixed(0)}%)`;
-          ctx.fill(paths[hb][l]);
+          // Scale the pure color toward black: level 0 ≈ 0% brightness,
+          // top level = full 100% saturated R/G/B.
+          const b = (l + 1) / LEVELS;
+          ctx.fillStyle = `rgb(${Math.round(c[0] * b)}, ${Math.round(
+            c[1] * b
+          )}, ${Math.round(c[2] * b)})`;
+          ctx.fill(paths[ci][l]);
         }
       }
     }

--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -62,42 +62,23 @@ const word = "MLKFS";
     const amp = reduceMotion ? 0.12 : 0.26; // radius pulse amplitude
     const base = 1 - amp; // keeps peak radius ~constant across modes
     const moveScale = reduceMotion ? 0.5 : 1; // gentler drift in low-power mode
+    const hueSpeed = reduceMotion ? 8 : 20; // how fast the rainbow flows (°/s)
 
-    // Print-channel palette: black, blue, red, green.
-    const palette: RGB[] = [
-      [17, 17, 17],
-      [0, 71, 255],
-      [255, 45, 45],
-      [0, 177, 64],
-    ];
-
-    // Shimmer levels: each color is pre-shaded into LEVELS brightness steps so
-    // the silk catches light on wave crests and darkens in troughs, while we
-    // still only issue a handful of fills per frame. (Must come after `palette`.)
-    const LEVELS = 5;
-    const mix = (c: RGB, target: number, t: number): RGB =>
-      [
-        Math.round(c[0] + (target - c[0]) * t),
-        Math.round(c[1] + (target - c[1]) * t),
-        Math.round(c[2] + (target - c[2]) * t),
-      ] as RGB;
-    const shades: string[][] = palette.map((c) => {
-      const row: string[] = [];
-      for (let l = 0; l < LEVELS; l++) {
-        const k = (l + 0.5) / LEVELS; // 0..1 across the level band
-        let s: RGB;
-        if (k >= 0.5) s = mix(c, 255, (k - 0.5) * 2 * 0.5); // crest → toward white
-        else s = mix(c, 0, (0.5 - k) * 2 * 0.45); // trough → toward black
-        row.push(`rgb(${s[0]}, ${s[1]}, ${s[2]})`);
-      }
-      return row;
-    });
+    // Full-spectrum rainbow: dots take a hue from their position and the whole
+    // band drifts over time, so the word is made of every color (no black).
+    // We quantise hue + lightness into bins so a frame still issues a small,
+    // fixed number of fills.
+    const HUE_BINS = 36; // 10° steps
+    const LEVELS = 5; // shimmer (lightness) steps
+    const SAT = 85; // %
+    const L_MIN = 40; // trough lightness %
+    const L_MAX = 74; // crest lightness %
 
     type Dot = {
       x: number;
       y: number;
       cov: number; // 0..1 coverage from the text mask
-      ci: number; // palette/color index
+      hue: number; // base hue 0..360 (position-based)
     };
 
     let dots: Dot[] = [];
@@ -157,13 +138,14 @@ const word = "MLKFS";
           const idx = (Math.floor(y) * mask.width + Math.floor(x)) * 4 + 3;
           const cov = data[idx] / 255; // alpha = inside the letters
           if (cov < 0.04) continue;
-          // Cluster colors with a low-frequency pattern + a little noise so it
-          // reads as misregistered print channels rather than random confetti.
-          const region =
-            Math.floor(x / (gap * 6)) + Math.floor(y / (gap * 6)) * 2;
-          const jitter = Math.floor((Math.sin(x * 12.9 + y * 78.2) + 1) * 1.7);
-          const ci = (region + jitter) % palette.length;
-          dots.push({ x, y, cov, ci });
+          // Hue from position: a smooth left→right spectrum across the word,
+          // with a touch of vertical shift and noise so it shimmers like a
+          // rainbow on silk rather than clean vertical bands.
+          const sweep = (x / canvas.width) * 300; // most of the wheel L→R
+          const tilt = (y / canvas.height) * 60;
+          const noise = Math.sin(x * 0.05 + y * 0.08) * 12;
+          const hue = (sweep + tilt + noise + 360) % 360;
+          dots.push({ x, y, cov, hue });
         }
       }
     }
@@ -172,10 +154,11 @@ const word = "MLKFS";
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const time = t * 0.001;
       const sway = maxR * 0.9 * moveScale; // how far dots drift (px)
+      const hueShift = (time * hueSpeed) % 360; // rainbow flows over time
 
-      // One Path2D per (color, shade level) so shimmer stays cheap:
-      // palette.length * LEVELS fills per frame, regardless of dot count.
-      const paths: Path2D[][] = palette.map(() =>
+      // One Path2D per (hue bin, lightness level) so the frame issues a small,
+      // fixed number of fills no matter how many dots there are.
+      const paths: Path2D[][] = Array.from({ length: HUE_BINS }, () =>
         Array.from({ length: LEVELS }, () => new Path2D())
       );
 
@@ -201,17 +184,31 @@ const word = "MLKFS";
           LEVELS - 1,
           Math.max(0, Math.floor((field * 0.5 + 0.5) * LEVELS))
         );
-        const p = paths[d.ci][lvl];
+        // Pull the hue toward the three screen primaries (R 0°, G 120°, B 240°)
+        // so the wordmark reads as RGB — fitting for work made for screens —
+        // while still passing through yellow/cyan/magenta in the transitions.
+        const u = (((d.hue + hueShift) % 360) + 360) % 360 / 360; // 0..1
+        const s = u * 3;
+        const seg = Math.floor(s);
+        const f = s - seg; // 0..1 within an R→G→B leg
+        const k = 2.4; // >1 widens the pure primaries, narrows the blends
+        const fp =
+          f < 0.5 ? 0.5 * Math.pow(2 * f, k) : 1 - 0.5 * Math.pow(2 - 2 * f, k);
+        const snapped = ((seg + fp) / 3) % 1; // back to 0..1
+        const hb = Math.floor(snapped * HUE_BINS) % HUE_BINS;
+        const p = paths[hb][lvl];
         const px = d.x + dx;
         const py = d.y + dy;
         p.moveTo(px + r, py);
         p.arc(px, py, r, 0, Math.PI * 2);
       }
 
-      for (let ci = 0; ci < palette.length; ci++) {
+      for (let hb = 0; hb < HUE_BINS; hb++) {
+        const hue = (hb + 0.5) * (360 / HUE_BINS);
         for (let l = 0; l < LEVELS; l++) {
-          ctx.fillStyle = shades[ci][l];
-          ctx.fill(paths[ci][l]);
+          const light = L_MIN + ((l + 0.5) / LEVELS) * (L_MAX - L_MIN);
+          ctx.fillStyle = `hsl(${hue.toFixed(0)}, ${SAT}%, ${light.toFixed(0)}%)`;
+          ctx.fill(paths[hb][l]);
         }
       }
     }

--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -94,6 +94,8 @@ const word = "MLKFS";
       ci: number; // color index: 0=R, 1=G, 2=B
       seed: number; // per-dot random phase (0..1) for twinkle/flicker
       tw: number; // twinkle speed multiplier (matrix-like flicker)
+      cs: number; // matrix column fall speed
+      cp: number; // matrix column phase offset
     };
 
     let dots: Dot[] = [];
@@ -160,6 +162,11 @@ const word = "MLKFS";
           const rnd = h - Math.floor(h); // 0..1
           const h2 = Math.sin((x * 269.5 + y * 183.3) + SEED * 9277.3) * 24634.6345;
           const rnd2 = h2 - Math.floor(h2); // 0..1
+          // Column hash (x only): dots in the same column share a fall stream,
+          // re-seeded per visit, so brightness rains straight down like a
+          // terminal of fast-scrolling code.
+          const hc = Math.sin(x * 73.13 + SEED * 4177.1) * 19349.1;
+          const colR = hc - Math.floor(hc); // 0..1
           dots.push({
             x,
             y,
@@ -167,6 +174,8 @@ const word = "MLKFS";
             ci: Math.floor(rnd * 3) % 3, // random R/G/B per dot (per visit)
             seed: rnd,
             tw: 0.6 + rnd2 * 2.2, // each dot flickers at its own rate
+            cs: 0.5 + colR * 0.9, // fall speed (screens of canvas height / s)
+            cp: colR, // column phase offset (0..1)
           });
         }
       }
@@ -199,17 +208,27 @@ const word = "MLKFS";
         const dx = sway * 0.35 * Math.cos(nx + time * 0.9);
         const dy = sway * Math.cos(ny - time * 0.6);
 
-        // Per-dot random flicker (matrix): each dot pulses on its own phase and
-        // rate, layered on the smooth silk wave.
+        // Per-dot random flicker, layered on the smooth wave.
         const flickW = Math.sin(time * d.tw + d.seed * 6.283);
 
-        // Brightness swings the full 0..1 (i.e. 0..100%): the wave + flicker
-        // drive each dot from black up to fully bright and back.
+        // Matrix rain: a bright head falls down each column and leaves a fading
+        // tail, so brightness scrolls top→bottom like terminal code. `head` is
+        // the column's lit position (0..1 of height), wrapping as it falls.
+        const yN = d.y / canvas.height; // 0(top)..1(bottom)
+        const head = ((time * d.cs + d.cp) % 1 + 1) % 1;
+        let below = head - yN; // distance from the head, downward
+        if (below < 0) below += 1; // wrap so the stream is continuous
+        const tail = 0.32; // tail length (fraction of height)
+        const rain =
+          below < tail ? 1 - below / tail : 0; // 1 at head → 0 at tail end
+
+        // Combine: the falling stream dominates, with the wave + flicker adding
+        // life so it isn't a perfectly even scroll.
         const liteT = Math.min(
           1,
           Math.max(
             0,
-            0.5 + wave * 0.5 * field + flick * 0.5 * flickW + 0.18
+            0.12 + 0.95 * rain + wave * 0.25 * field + flick * 0.2 * flickW
           )
         );
 

--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -46,6 +46,17 @@ const word = "MLKFS";
     if (!ctx) return;
 
     const word = root.dataset.word || "MLKFS";
+
+    // Per-visit randomness: a fresh seed every time the page loads, so no two
+    // sessions (even two computers opening at the same instant) ever produce the
+    // same frame. It mixes a crypto/time source into both the per-dot hashes and
+    // a random start time, so the loop begins at a different phase each visit.
+    const seed32 =
+      (typeof crypto !== "undefined" && crypto.getRandomValues
+        ? crypto.getRandomValues(new Uint32Array(1))[0]
+        : (Date.now() ^ (Math.random() * 0xffffffff)) >>> 0) || 1;
+    const SEED = seed32 / 0xffffffff; // 0..1
+    const startOffset = SEED * 100000; // random point in the loop (ms-ish)
     // Match the site's system font: SF (San Francisco) on Apple devices, then
     // Segoe/Helvetica/Arial elsewhere. We list -apple-system/BlinkMacSystemFont
     // (which Safari's canvas honours) rather than the `system-ui`/`ui-sans-serif`
@@ -59,8 +70,11 @@ const word = "MLKFS";
     const reduceMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)"
     ).matches;
-    const amp = reduceMotion ? 0.12 : 0.26; // radius pulse amplitude
-    const base = 1 - amp; // keeps peak radius ~constant across modes
+    // Blend of two feels: a smooth silk wave + a random per-dot flicker
+    // (digital matrix). `wave`/`flick` are how much each contributes to the
+    // size pulse; together they make some dots nearly vanish and pop back.
+    const wave = reduceMotion ? 0.14 : 0.30; // smooth rippling component
+    const flick = reduceMotion ? 0.10 : 0.40; // random twinkle component
     const moveScale = reduceMotion ? 0.5 : 1; // gentler drift in low-power mode
     const hueSpeed = reduceMotion ? 8 : 20; // how fast the rainbow flows (°/s)
 
@@ -79,6 +93,9 @@ const word = "MLKFS";
       y: number;
       cov: number; // 0..1 coverage from the text mask
       hue: number; // base hue 0..360 (position-based)
+      seed: number; // per-dot random phase (0..1) for twinkle/flicker
+      tw: number; // twinkle speed multiplier (matrix-like flicker)
+      hj: number; // per-dot hue jitter in degrees
     };
 
     let dots: Dot[] = [];
@@ -145,14 +162,30 @@ const word = "MLKFS";
           const tilt = (y / canvas.height) * 60;
           const noise = Math.sin(x * 0.05 + y * 0.08) * 12;
           const hue = (sweep + tilt + noise + 360) % 360;
-          dots.push({ x, y, cov, hue });
+          // Per-dot randomness, re-seeded every visit: position hashes are
+          // mixed with this session's SEED so the same pixel looks different
+          // each load. Two machines opening together still differ.
+          const h = Math.sin((x * 127.1 + y * 311.7) + SEED * 6131.7) * 43758.5453;
+          const rnd = h - Math.floor(h); // 0..1
+          const h2 = Math.sin((x * 269.5 + y * 183.3) + SEED * 9277.3) * 24634.6345;
+          const rnd2 = h2 - Math.floor(h2); // 0..1
+          dots.push({
+            x,
+            y,
+            cov,
+            hue: (hue + SEED * 360) % 360, // whole spectrum is rotated per visit
+            seed: rnd,
+            tw: 0.6 + rnd2 * 2.2, // each dot flickers at its own rate
+            hj: (rnd2 - 0.5) * 50, // ±25° hue scatter
+          });
         }
       }
     }
 
     function draw(t: number) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const time = t * 0.001;
+      // Offset the clock per visit so the loop starts at a random phase.
+      const time = (t + startOffset) * 0.001;
       const sway = maxR * 0.9 * moveScale; // how far dots drift (px)
       const hueShift = (time * hueSpeed) % 360; // rainbow flows over time
 
@@ -177,17 +210,25 @@ const word = "MLKFS";
         const dx = sway * 0.35 * Math.cos(nx + time * 0.9);
         const dy = sway * Math.cos(ny - time * 0.6);
 
-        const r = d.cov * maxR * (base + amp * field);
+        // Per-dot random flicker (matrix): each dot pulses on its own phase and
+        // rate, layered on the smooth silk wave. Mostly bright with occasional
+        // near-zero dips so cells blink in and out.
+        const flickW = Math.sin(time * d.tw + d.seed * 6.283);
+        const mul = 1 - wave * 0.5 + wave * 0.5 * field + flick * flickW;
+        const r = d.cov * maxR * Math.max(0, mul);
         if (r <= 0.2) continue;
 
+        // Lightness follows the combined motion so bright dots also pop in tone.
+        const liteT = (field * 0.5 + 0.5) * 0.5 + (flickW * 0.5 + 0.5) * 0.5;
         const lvl = Math.min(
           LEVELS - 1,
-          Math.max(0, Math.floor((field * 0.5 + 0.5) * LEVELS))
+          Math.max(0, Math.floor(liteT * LEVELS))
         );
         // Pull the hue toward the three screen primaries (R 0°, G 120°, B 240°)
         // so the wordmark reads as RGB — fitting for work made for screens —
         // while still passing through yellow/cyan/magenta in the transitions.
-        const u = (((d.hue + hueShift) % 360) + 360) % 360 / 360; // 0..1
+        // d.hj scatters each dot's hue so colors don't form clean bands.
+        const u = ((((d.hue + d.hj + hueShift) % 360) + 360) % 360) / 360; // 0..1
         const s = u * 3;
         const seg = Math.floor(s);
         const f = s - seg; // 0..1 within an R→G→B leg


### PR DESCRIPTION
## Summary

Evolves the animated "MLKFS" hero into an RGB matrix-rain wordmark.

- **Pure RGB:** dots are only red/green/blue at full saturation; brightness swings the full 0–100% (no black palette entry). From a distance the three colors blend.
- **Matrix rain:** brightness scrolls top→bottom — each column lights a bright head that falls with a fading tail, like fast terminal code. The silk wave + per-dot flicker add life on top.
- **Per-visit randomness:** all randomness (dot color, flicker, column fall speed/phase, animation start phase) is re-seeded every load from `crypto.getRandomValues` (time/`Math.random` fallback). No two visits render the same frame.
- **SF font + iOS fixes** from earlier commits are included.

## Verification
- `npm run build` passes (10 pages).
- Headless: no errors, canvas fills; two separate visits produce different frames.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_