### PR TITLE
Hidden dev gate: 7 logo taps open the hero lab

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -140,5 +140,27 @@ const links = [
     if (e.target.closest('#nav-toggle') || e.target.closest('.link') || e.target.closest('.logo-link')) return;
     if (inStripArea(e)) window.location.href = '/';
   });
+
+  // Hidden dev gate: tap the logo 7 times quickly (like Android's build number)
+  // to open the hero lab. A single tap still goes home — we just hold navigation
+  // briefly so taps can accumulate (clicking the <a> would otherwise reload and
+  // reset the count).
+  let tapCount = 0;
+  let tapTimer = 0;
+  logoLink?.addEventListener('click', (e) => {
+    e.preventDefault();
+    tapCount++;
+    clearTimeout(tapTimer);
+    if (tapCount >= 7) {
+      tapCount = 0;
+      window.location.href = '/hero-lab.html';
+      return;
+    }
+    // After a short pause with no further taps, treat it as a normal logo click.
+    tapTimer = setTimeout(() => {
+      tapCount = 0;
+      if (window.location.pathname !== '/') window.location.href = '/';
+    }, 450);
+  });
 </script>
 </nav>


### PR DESCRIPTION
## Summary

Adds a hidden developer gate: tapping the navbar logo **7 times quickly** (like Android's build-number tap) opens `/hero-lab.html`.

- A single logo tap still navigates home. Navigation is held ~450ms so rapid taps can accumulate instead of the `<a href="/">` reloading and resetting the count.
- 7 taps within the window → jump to the hero lab.

## Verification
- `npm run build` passes.
- Headless: 7 quick taps → `/hero-lab.html`; a single tap from a sub-page → `/`; no JS errors.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_