### PR TITLE
Hero lab: smooth + performant Evolve (integrated phases, skip empty paths)

### DIFF
--- a/public/hero-lab.html
+++ b/public/hero-lab.html
@@ -173,7 +173,8 @@ document.getElementById("dev-mobile").addEventListener("click", ()=>setDevice("m
 
 // ---- Evolve mode: every variable drifts at its own (seedable) speed ----
 let SEED = Math.random();
-let evolveOn = false, evolveSpeed = 1, evolveDepth = 0.5, lastTsec = 0, lastBuild = 0;
+let evolveOn = false, evolveSpeed = 1, evolveDepth = 0.5, lastTsec = 0;
+let silkAcc = 0, lastDrawT = 0;   // integrated phases keep motion smooth as speeds drift
 const evoSpeed = {};              // per-variable change-speed multiplier (0 = frozen)
 for (const k in DEFAULTS) evoSpeed[k] = 1;
 let EVO = {};                     // per-variable base rate + phase, derived from SEED
@@ -301,17 +302,23 @@ function build(){
     const gx=Math.min(cols-1,Math.floor(x/gap)), gy=Math.min(rowsN-1,Math.floor(y/gap));
     const raw=near[gy*cols+gx]; const inWord=raw*raw*(3-2*raw);
     const r1=rand(x,y), r2=rand(x+7.3,y-3.1), r3=rand(x*0.5+19,y*0.7+5), r4=rand(x-11,y+23);
-    dots.push({ x,y,inWord, ph:r1*6.283, sp:r2, hph:r3*6.283, hsp:r4, hue0:r1, bias:0.6+r2*1.1 });
+    // pAcc / hAcc are integrated phases (seeded start offsets); sp/hsp are per-dot rates
+    dots.push({ x,y,inWord, pAcc:r1*6.283, sp:r2, hAcc:r3*6.283*0.02, hsp:r4, hue0:r1 });
   }
   document.getElementById("dotcount").textContent = dots.length + " dots";
 }
 
 function draw(t){
+  const dt = Math.min(0.05, lastDrawT ? (t - lastDrawT) * 0.001 : 0.016);
+  lastDrawT = t;
+  const paceDt = dt * EP.pace;                  // integrate phases — drifting speeds never jump
+  silkAcc += paceDt * EP.silkSpeed;
   ctx.clearRect(0,0,canvas.width,canvas.height);
-  const time=(t)*0.001*EP.pace;
   const colorPaths = Array.from({length:HUE_BINS},()=>Array.from({length:LEVELS},()=>new Path2D()));
-  const grayPaths = Array.from({length:LEVELS},()=>new Path2D());
-  const wt=time*EP.silkSpeed;
+  const grayPaths  = Array.from({length:LEVELS},()=>new Path2D());
+  const colorN = Array.from({length:HUE_BINS},()=>new Int16Array(LEVELS));   // path occupancy
+  const grayN  = new Int16Array(LEVELS);
+  const wt=silkAcc;
   const silkAt=(x,y)=>{ const nx=x*EP.silkFreqX, ny=y*EP.silkFreqY;
     const w=Math.sin(nx+wt*0.9)+0.7*Math.sin(ny-wt*0.6)+0.5*Math.sin((nx+ny)*0.6+wt*1.3);
     return 0.5+0.5*(w/2.2); };
@@ -319,34 +326,38 @@ function draw(t){
   const pSpan=Math.max(0, EP.pulseMax-EP.pulseMin);
   for(const d of dots){
     const sp=EP.pulseMin + d.sp*pSpan;
-    const ownPulse=0.5+0.5*Math.sin(time*sp+d.ph);
+    d.pAcc += paceDt * sp;                       // pulse phase
+    d.hAcc += paceDt * EP.hueSpeed * 0.25 * d.hsp; // hue phase
+    const ownPulse=0.5+0.5*Math.sin(d.pAcc);
     const near=d.inWord;
     const silk=silkAt(d.x,d.y);
     const pulse=silk+(ownPulse-silk)*near;
-    const r=Math.min(rMax,(EP.sizeBase+near*EP.sizeNear+EP.sizePulse*pulse)*gapR);
-    if(r<=0.3) continue;
     const bright=Math.min(1,EP.brightBase+EP.brightPulse*pulse);
     const bl=Math.min(LEVELS-1,Math.max(0,Math.floor(bright*LEVELS)));
     if(near<0.5){
       const rb=Math.min(rMax,(EP.sizeBase*0.5 + EP.bgSize*pulse)*gapR);
       if(rb<=0.3) continue;
-      grayPaths[bl].moveTo(d.x+rb,d.y); grayPaths[bl].arc(d.x,d.y,rb,0,6.2832);
+      grayPaths[bl].moveTo(d.x+rb,d.y); grayPaths[bl].arc(d.x,d.y,rb,0,6.2832); grayN[bl]++;
     } else {
-      const hb=Math.floor((((d.hue0+time*EP.hueSpeed*0.25*d.hsp+d.hph*0.02)%1)+1)%1*HUE_BINS)%HUE_BINS;
-      colorPaths[hb][bl].moveTo(d.x+r,d.y); colorPaths[hb][bl].arc(d.x,d.y,r,0,6.2832);
+      const r=Math.min(rMax,(EP.sizeBase+near*EP.sizeNear+EP.sizePulse*pulse)*gapR);
+      if(r<=0.3) continue;
+      const hb=Math.floor((((d.hue0+d.hAcc)%1)+1)%1*HUE_BINS)%HUE_BINS;
+      colorPaths[hb][bl].moveTo(d.x+r,d.y); colorPaths[hb][bl].arc(d.x,d.y,r,0,6.2832); colorN[hb][bl]++;
     }
   }
-  // gray bg
+  // gray bg (skip empty levels)
   for(let bl=0; bl<LEVELS; bl++){
+    if(!grayN[bl]) continue;
     const b=(bl+1)/LEVELS; const g=Math.round(EP.bgGray+(255-EP.bgGray)*(1-b));
     ctx.fillStyle=`rgb(${g},${g},${g})`; ctx.fill(grayPaths[bl]);
   }
-  // colored additive
+  // colored additive (skip empty bins)
   lctx.clearRect(0,0,layer.width,layer.height);
   lctx.globalCompositeOperation="lighter";
   for(let hb=0; hb<HUE_BINS; hb++){
     const c=wheel((hb+0.5)/HUE_BINS);
     for(let bl=0; bl<LEVELS; bl++){
+      if(!colorN[hb][bl]) continue;
       const b=(bl+1)/LEVELS;
       // desaturate toward gray-white by EP.sat
       const mixv=(ch)=>{ const full=ch*b; const grayv=255*b*0.6; return Math.round(grayv+(full-grayv)*EP.sat); };


### PR DESCRIPTION
## Summary

Keeps the "animate all variables" breathing look you loved, but makes the motion buttery-smooth and lighter on the CPU/GPU.

**Smoothness (the real fix):** `pace`, `silkSpeed`, `hueSpeed` and the pulse range are *themselves* drifting. The old code computed motion as `t * speed(t)`, so whenever a speed changed, the phase jumped (or briefly ran backwards). Now every phase is **integrated** each frame (`phase += dt * speed`), so motion stays continuous no matter how the speeds drift. Pulse and hue use per-dot accumulators; silk uses a global one.

**Performance pass:**
- Track path occupancy and **skip filling empty** hue×level bins (most bins are empty at any moment).
- Compute the colored-dot radius only in the colored branch.
- (Earlier change already removed the per-frame grid rebuild.)

## Verification
- `npm run build` passes.
- Headless, Evolve on (speed 3.5, depth 0.84): **~51 fps** desktop @2× (~4800 dots), **60 fps** mobile preview, no JS errors; logo renders correctly (MLKFS, breathing colored dots over the gray silk field).

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_