### PR TITLE
Hero lab: halo 0 default + background on/off toggle

### DIFF
--- a/public/hero-lab.html
+++ b/public/hero-lab.html
@@ -82,7 +82,7 @@
 const DEFAULTS = {
   // grid / shape (rebuild on change)
   gap:            { v: 9,    min: 5,   max: 22,  step: 1,    label: "Dot spacing (px)", rebuild: true },
-  blur:           { v: 2,    min: 0,   max: 5,   step: 1,    label: "Letter halo / fade (cells)", rebuild: true },
+  blur:           { v: 0,    min: 0,   max: 5,   step: 1,    label: "Letter halo / fade (cells)", rebuild: true },
   fillWidth:      { v: 0.92, min: 0.5, max: 1,   step: 0.01, label: "Word width fill", rebuild: true },
 
   // motion
@@ -103,6 +103,7 @@ const DEFAULTS = {
   sat:            { v: 1.0,  min: 0.3, max: 1,   step: 0.02, label: "Color saturation" },
 
   // background (gray, silk)
+  bgShow:         { v: 1,    min: 0,   max: 1,   step: 1,    label: "Background on/off", fixed: true },
   bgGray:         { v: 205,  min: 120, max: 250, step: 1,    label: "Bg gray (low=darker)" },
   bgSize:         { v: 0.30, min: 0,   max: 0.8, step: 0.02, label: "Bg dot size" },
   silkSpeed:      { v: 2.2,  min: 0,   max: 6,   step: 0.1,  label: "Silk wave speed" },
@@ -115,7 +116,7 @@ const GROUPS = [
   ["Motion", ["pace","pulseMin","pulseMax","hueSpeed"]],
   ["Dot size", ["rMax","sizeBase","sizeNear","sizePulse"]],
   ["Color", ["brightBase","brightPulse","sat"]],
-  ["Background (silk)", ["bgGray","bgSize","silkSpeed","silkFreqX","silkFreqY"]],
+  ["Background (silk)", ["bgShow","bgGray","bgSize","silkSpeed","silkFreqX","silkFreqY"]],
 ];
 
 // Two independent configs — desktop and mobile keep separate values.
@@ -192,9 +193,9 @@ function computeEP(tsec){
   const o = {};
   for (const k in DEFAULTS){
     const d = DEFAULTS[k]; let v = P[k];
-    // Structural params (grid spacing/halo/width) never drift — rebuilding the
-    // grid every frame makes the dots jump. They stay fixed per device/resolution.
-    if (evolveOn && EVO[k] && !d.rebuild){
+    // Structural (grid) and fixed (toggles) params never drift — rebuilding the
+    // grid every frame makes dots jump, and toggles shouldn't flip randomly.
+    if (evolveOn && EVO[k] && !d.rebuild && !d.fixed){
       const swing = evolveDepth * (d.max - d.min) / 2;
       const rate  = EVO[k].rate * evoSpeed[k] * evolveSpeed;
       v += Math.sin(tsec * rate + EVO[k].phase) * swing;
@@ -230,7 +231,7 @@ const fmt = (v, step) => step >= 1 ? Math.round(v) : Math.round(v*100)/100;
     <p class="hint" style="margin:0 0 8px">Grid spacing / halo / width stay fixed (set them per device above) — drifting them rebuilds the grid and makes the dots stutter.</p>`;
   for (const k in DEFAULTS){
     const d = DEFAULTS[k];
-    if (d.rebuild) continue;                 // structural params don't evolve
+    if (d.rebuild || d.fixed) continue;      // structural / toggle params don't evolve
     const row = document.createElement("div"); row.className = "row";
     row.innerHTML = `<label>${d.label}</label><span class="val" id="es_v_${k}">1</span>
       <input id="es_${k}" type="range" min="0" max="5" step="0.1" value="1">`;
@@ -335,6 +336,7 @@ function draw(t){
     const bright=Math.min(1,EP.brightBase+EP.brightPulse*pulse);
     const bl=Math.min(LEVELS-1,Math.max(0,Math.floor(bright*LEVELS)));
     if(near<0.5){
+      if(EP.bgShow<0.5) continue;                 // background removed
       const rb=Math.min(rMax,(EP.sizeBase*0.5 + EP.bgSize*pulse)*gapR);
       if(rb<=0.3) continue;
       grayPaths[bl].moveTo(d.x+rb,d.y); grayPaths[bl].arc(d.x,d.y,rb,0,6.2832); grayN[bl]++;


### PR DESCRIPTION
## Summary

Two lab tweaks from exploring the breathing look:

- **Letter halo defaults to 0** — crisp, dense letters (the lava-lamp look). Still adjustable up to 5 if you want soft edges.
- **Background on/off toggle (`bgShow`)** — per device. When off, the gray silk field is skipped entirely (also saves work), leaving only the colored letter dots. The toggle is *fixed*: it never evolves and has no change-speed slider, and it's written into the exported config.

## Verification
- `npm run build` passes.
- Headless: `blur` default `0`; `s_bgShow` exists, no `es_bgShow` (excluded from evolve); turning it off removes the gray field (screenshot shows only colored letter dots); `Copy config` includes `"bgShow"` and `"blur": 0`; no JS errors.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_