### PR TITLE
Move 7-tap dev gate from logo to the hero animation

### DIFF
--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -399,6 +399,20 @@ const word = "MLKFS";
       resizeTimer = window.setTimeout(start, 150);
     });
 
+    // Hidden gate: the dotted hero looks interactive — so reward the curious.
+    // 7 clicks on the animation within a short window opens the hero lab.
+    let heroTaps = 0;
+    let heroTapTimer = 0;
+    canvas.addEventListener("click", () => {
+      heroTaps += 1;
+      window.clearTimeout(heroTapTimer);
+      heroTapTimer = window.setTimeout(() => { heroTaps = 0; }, 1500);
+      if (heroTaps >= 7) {
+        heroTaps = 0;
+        window.location.href = "/hero-lab.html";
+      }
+    });
+
     start();
   }
 

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -140,27 +140,5 @@ const links = [
     if (e.target.closest('#nav-toggle') || e.target.closest('.link') || e.target.closest('.logo-link')) return;
     if (inStripArea(e)) window.location.href = '/';
   });
-
-  // Hidden dev gate: tap the logo 7 times quickly (like Android's build number)
-  // to open the hero lab. A single tap still goes home — we just hold navigation
-  // briefly so taps can accumulate (clicking the <a> would otherwise reload and
-  // reset the count).
-  let tapCount = 0;
-  let tapTimer = 0;
-  logoLink?.addEventListener('click', (e) => {
-    e.preventDefault();
-    tapCount++;
-    clearTimeout(tapTimer);
-    if (tapCount >= 7) {
-      tapCount = 0;
-      window.location.href = '/hero-lab.html';
-      return;
-    }
-    // After a short pause with no further taps, treat it as a normal logo click.
-    tapTimer = setTimeout(() => {
-      tapCount = 0;
-      if (window.location.pathname !== '/') window.location.href = '/';
-    }, 450);
-  });
 </script>
 </nav>


### PR DESCRIPTION
## Summary

Moves the hidden 7-tap dev gate off the logo and onto the hero animation.

- **Logo** goes back to its normal job: a single click navigates home, no interception.
- **Hero animation** is the new secret door: the dotted screen looks interactive, so people hover and click to see if it reacts — 7 clicks within a short window opens `/hero-lab.html`.

No visual change to the hero; the gate is invisible.

## Verification
- `npm run build` passes.
- Headless: 7 clicks on `.hero-reel__canvas` → `/hero-lab.html`; a single logo click from `/about` → `/`; no JS errors.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_