### PR TITLE
Hero: wider bokeh swing; lab defaults to evolve on / depth 1

### DIFF
--- a/public/hero-lab.html
+++ b/public/hero-lab.html
@@ -175,7 +175,7 @@ document.getElementById("dev-mobile").addEventListener("click", ()=>setDevice("m
 
 // ---- Evolve mode: every variable drifts at its own (seedable) speed ----
 let SEED = Math.random();
-let evolveOn = false, evolveSpeed = 1, evolveDepth = 0.5, lastTsec = 0;
+let evolveOn = true, evolveSpeed = 1, evolveDepth = 1, lastTsec = 0;
 let silkAcc = 0, lastDrawT = 0;   // integrated phases keep motion smooth as speeds drift
 const evoSpeed = {};              // per-variable change-speed multiplier (0 = frozen)
 for (const k in DEFAULTS) evoSpeed[k] = 1;
@@ -214,11 +214,11 @@ const fmt = (v, step) => step >= 1 ? Math.round(v) : Math.round(v*100)/100;
   const g = document.createElement("div"); g.className = "group";
   g.innerHTML = `<h2>Evolve (auto-drift)</h2>
     <div class="row check"><label for="evo_on">Animate all variables</label>
-      <input id="evo_on" type="checkbox" style="width:18px;height:18px;accent-color:var(--accent)"></div>
+      <input id="evo_on" type="checkbox" checked style="width:18px;height:18px;accent-color:var(--accent)"></div>
     <div class="row"><label>Global speed ×</label><span class="val" id="v_evos">1</span>
       <input id="s_evos" type="range" min="0" max="4" step="0.05" value="1"></div>
-    <div class="row"><label>Depth (swing)</label><span class="val" id="v_evod">0.5</span>
-      <input id="s_evod" type="range" min="0" max="1" step="0.02" value="0.5"></div>
+    <div class="row"><label>Depth (swing)</label><span class="val" id="v_evod">1</span>
+      <input id="s_evod" type="range" min="0" max="1" step="0.02" value="1"></div>
     <p class="hint" style="margin:8px 0 0">Each variable drifts on its own seeded rhythm — “New random seed” gives a fresh combination.</p>`;
   panel.prepend(g);
   const on = g.querySelector("#evo_on");

--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -79,24 +79,27 @@ const word = "MLKFS";
     // on the live site (it would reveal the canvas's rectangular edges), so only
     // the colored letter dots show. Structural values (spacing/halo/width) stay
     // fixed, and phases are integrated, so nothing ever stutters.
-    const DEPTH = reduceMotion ? 0.32 : 0.5; // how far each variable swings
-    const ESPEED = reduceMotion ? 0.4 : 0.6; // how fast the drift cycles
-    // base = the established look; amp = breathing amplitude around it.
-    const PARAMS: Record<string, { base: number; amp: number }> = {
-      pace: { base: 0.35, amp: 0.16 },
-      pulseMin: { base: 0.25, amp: 0.15 },
-      pulseMax: { base: 1.15, amp: 0.5 },
-      hueSpeed: { base: 0.25, amp: 0.2 },
-      rMax: { base: 0.62, amp: 0.1 },
-      sizeBase: { base: 0.12, amp: 0.06 },
-      sizeNear: { base: 0.5, amp: 0.12 },
-      sizePulse: { base: 0.18, amp: 0.1 },
-      brightBase: { base: 0.35, amp: 0.12 },
-      brightPulse: { base: 0.65, amp: 0.18 },
-      sat: { base: 0.9, amp: 0.12 },
-      silkSpeed: { base: 2.2, amp: 0.9 },
-      silkFreqX: { base: 0.012, amp: 0.004 },
-      silkFreqY: { base: 0.016, amp: 0.005 },
+    // Wide, lively swing — at full depth the dots blow up and overlap into soft
+    // bokeh-like blobs, then resolve back into a crisp MLKFS, over and over.
+    const DEPTH = reduceMotion ? 0.4 : 1.0; // how far each variable swings
+    const ESPEED = reduceMotion ? 0.4 : 0.75; // how fast the drift cycles
+    // base = the established look; [min,max] = how far each variable may swing
+    // (clamped, so pace never freezes or reverses).
+    const PARAMS: Record<string, { base: number; min: number; max: number }> = {
+      pace: { base: 0.35, min: 0.1, max: 0.75 },
+      pulseMin: { base: 0.25, min: 0.05, max: 1.1 },
+      pulseMax: { base: 1.15, min: 0.6, max: 2.4 },
+      hueSpeed: { base: 0.25, min: 0, max: 1.2 },
+      rMax: { base: 0.62, min: 0.38, max: 1.1 },
+      sizeBase: { base: 0.12, min: 0, max: 0.4 },
+      sizeNear: { base: 0.5, min: 0.28, max: 0.9 },
+      sizePulse: { base: 0.18, min: 0.05, max: 0.55 },
+      brightBase: { base: 0.35, min: 0.15, max: 0.6 },
+      brightPulse: { base: 0.65, min: 0.35, max: 0.95 },
+      sat: { base: 0.9, min: 0.55, max: 1 },
+      silkSpeed: { base: 2.2, min: 0.9, max: 4 },
+      silkFreqX: { base: 0.012, min: 0.006, max: 0.022 },
+      silkFreqY: { base: 0.016, min: 0.008, max: 0.026 },
     };
     // Per-variable drift rate + phase, seeded so every visit evolves differently.
     const EVO: Record<string, { rate: number; phase: number }> = {};
@@ -116,9 +119,12 @@ const word = "MLKFS";
     function evolve(tsec: number) {
       for (const k in PARAMS) {
         const p = PARAMS[k];
-        EP[k] = p.base + Math.sin(tsec * EVO[k].rate + EVO[k].phase) * p.amp * DEPTH;
+        const swing = ((p.max - p.min) / 2) * DEPTH;
+        let v = p.base + Math.sin(tsec * EVO[k].rate + EVO[k].phase) * swing;
+        if (v < p.min) v = p.min;
+        else if (v > p.max) v = p.max;
+        EP[k] = v;
       }
-      if (EP.sat > 1) EP.sat = 1;
     }
     // Integrated accumulators — keep motion smooth even as speeds drift.
     let silkAcc = SEED * 50;


### PR DESCRIPTION
## Summary

Makes the homepage hero more random and lively — the bokeh look you found at depth 1 in the lab.

- **Homepage hero:** every visual variable now swings across a wide `[min,max]` range at full depth (`DEPTH = 1`), with faster drift (`ESPEED = 0.75`). Dots blow up and overlap into soft bokeh-like blobs, then resolve back into a crisp MLKFS — endlessly, each visit different. `pace` is clamped so it never freezes or reverses. Reduced-motion stays calm.
- **Lab:** opens with **Animate all variables** on and **Depth = 1** by default, so the breathing/bokeh look is there the moment you walk in.
- The lab welcome copy was already updated (PR #21) — included a re-check; it's the playful "you clicked the dots…" version.

## Verification
- `npm run build` passes.
- Headless: 60 fps @2×, no JS errors; frames over time show the swing from sparse/dark → dense bright bokeh → mid, always reading MLKFS.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_