### PR TITLE
Hero: analog flow on mobile — remove every mid-animation hitch

### DIFF
--- a/src/components/HeroReel.astro
+++ b/src/components/HeroReel.astro
@@ -139,7 +139,7 @@ const word = "MLKFS";
       [0, 0, 255], // B
     ];
     const HUE_BINS = 24; // quantised R→G→B→R wheel for cheap fills
-    const SOFT_TIERS = 3; // focus levels: 0 = crisp disc … 2 = soft bokeh glow
+    const SOFT_TIERS = 6; // focus levels: 0 = crisp disc … 5 = soft bokeh glow
 
     // The whole hero is a screen made of dots (a full grid). MLKFS lights up the
     // dots that fall inside the letters; dots outside stay as a dim background
@@ -175,6 +175,8 @@ const word = "MLKFS";
       const cssW = root.clientWidth;
       const cssH = root.clientHeight;
       if (cssW === 0 || cssH === 0) return;
+      builtW = cssW;
+      builtH = cssH;
 
       dpr = Math.min(window.devicePixelRatio || 1, 2);
       canvas.width = Math.round(cssW * dpr);
@@ -306,46 +308,43 @@ const word = "MLKFS";
     // of focus. Drawn additively, overlapping sprites pool into light — real
     // bokeh, not just big circles. One sprite per (focus tier × hue); brightness
     // is applied per dot via globalAlpha, so it's continuous (no banding).
-    // Saturation drifts slowly, so the cache is rebuilt only when it moves.
-    const SPRITE_PX = 64;
+    //
+    // The cache is built ONCE — never mid-animation. (Rebuilding it while the
+    // loop ran caused a synchronous hitch every few seconds, which read as the
+    // animation "ticking" instead of flowing, especially on phones.) Saturation
+    // drift is applied at composite time via a GPU canvas filter instead.
+    const SPRITE_PX = 48;
     let sprites: HTMLCanvasElement[][] = [];
-    let spriteSat = -1;
-    function buildSprites(sat: number) {
-      spriteSat = sat;
+    function buildSprites() {
       const half = SPRITE_PX / 2;
-      const gray = 255 * 0.6;
-      sprites = Array.from({ length: SOFT_TIERS }, (_, tier) =>
-        HUE_RGB.map((c) => {
+      sprites = Array.from({ length: SOFT_TIERS }, (_, tier) => {
+        // 0 = in focus … 1 = full bokeh; gradient morphs continuously so a dot
+        // crossing tiers never visibly pops.
+        const soft = tier / (SOFT_TIERS - 1);
+        const a0 = 1 - 0.15 * soft; // center alpha eases off as it defocuses
+        const hold = 0.78 * (1 - soft); // solid core shrinks away
+        const shoulder = Math.min(1, hold + (1 - hold) * 0.45);
+        return HUE_RGB.map((c) => {
           const cv = document.createElement("canvas");
           cv.width = cv.height = SPRITE_PX;
           const g = cv.getContext("2d")!;
-          const rr = Math.round(gray + (c[0] - gray) * sat);
-          const gg = Math.round(gray + (c[1] - gray) * sat);
-          const bb = Math.round(gray + (c[2] - gray) * sat);
-          const at = (a: number) => `rgba(${rr}, ${gg}, ${bb}, ${a})`;
+          const at = (a: number) =>
+            `rgba(${Math.round(c[0])}, ${Math.round(c[1])}, ${Math.round(c[2])}, ${a})`;
           const grad = g.createRadialGradient(half, half, 0, half, half, half);
-          if (tier === 0) {
-            // In focus: solid core, just enough edge softness to anti-alias.
-            grad.addColorStop(0, at(1));
-            grad.addColorStop(0.78, at(1));
-            grad.addColorStop(1, at(0));
-          } else if (tier === 1) {
-            // Slightly defocused: bright center easing out.
-            grad.addColorStop(0, at(1));
-            grad.addColorStop(0.4, at(0.85));
-            grad.addColorStop(1, at(0));
-          } else {
-            // Bokeh: a wide, airy glow that pools with its neighbours.
-            grad.addColorStop(0, at(0.85));
-            grad.addColorStop(0.35, at(0.5));
-            grad.addColorStop(1, at(0));
-          }
+          grad.addColorStop(0, at(a0));
+          if (hold > 0.01) grad.addColorStop(hold, at(a0));
+          grad.addColorStop(shoulder, at(a0 * 0.55));
+          grad.addColorStop(1, at(0));
           g.fillStyle = grad;
           g.fillRect(0, 0, SPRITE_PX, SPRITE_PX);
           return cv;
-        })
-      );
+        });
+      });
     }
+    buildSprites();
+    // Canvas 2D filters (for the drifting saturation) — supported everywhere
+    // modern; on older Safari we just stay fully saturated. Never a hitch.
+    const canFilter = typeof ctx.filter === "string";
 
     // Pointer = attention: dots near the cursor swim into focus and swell a
     // little, as if your gaze sharpens that part of the image.
@@ -384,9 +383,6 @@ const word = "MLKFS";
 
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       if (!lctx) return;
-
-      // Saturation drifts slowly — refresh the sprite cache when it has moved.
-      if (Math.abs(EP.sat - spriteSat) > 0.06) buildSprites(EP.sat);
 
       // Silk wave: crossing low-frequency waves over position + time, so the word
       // dots near the edges breathe coherently rather than twinkling at random.
@@ -452,7 +448,7 @@ const word = "MLKFS";
         const bright = Math.min(1, EP.brightBase + EP.brightPulse * pulse);
         const alpha = Math.max(0.05, bright * (1 - 0.55 * defocus));
         const rDraw = r * (1 + 1.6 * defocus);
-        const tier = defocus < 0.33 ? 0 : defocus < 0.66 ? 1 : 2;
+        const tier = Math.min(SOFT_TIERS - 1, Math.floor(defocus * SOFT_TIERS));
         const hb =
           Math.floor((((d.hue0 + d.hAcc) % 1) + 1) % 1 * HUE_BINS) % HUE_BINS;
 
@@ -468,7 +464,12 @@ const word = "MLKFS";
 
       lctx.globalAlpha = 1;
       lctx.globalCompositeOperation = "source-over";
+      // Drifting saturation is applied here, on the single composite draw — a
+      // GPU filter, smooth and continuous, instead of rebuilding sprite colors.
+      const wantFilter = canFilter && EP.sat < 0.98;
+      if (wantFilter) ctx.filter = `saturate(${Math.round(EP.sat * 100)}%)`;
       ctx.drawImage(layer, 0, 0);
+      if (wantFilter) ctx.filter = "none";
     }
 
     function loop(t: number) {
@@ -520,9 +521,17 @@ const word = "MLKFS";
     }
 
     let resizeTimer = 0;
+    let builtW = 0;
+    let builtH = 0;
     window.addEventListener("resize", () => {
       window.clearTimeout(resizeTimer);
-      resizeTimer = window.setTimeout(start, 150);
+      resizeTimer = window.setTimeout(() => {
+        // Mobile browsers fire resize when the URL bar collapses during scroll;
+        // the hero's size hasn't changed, so a full rebuild (and its hitch)
+        // isn't needed — only rebuild when the dimensions really moved.
+        if (root.clientWidth === builtW && root.clientHeight === builtH) return;
+        start();
+      }, 150);
     });
 
     // Hidden gate: the dotted hero looks interactive — so reward the curious.


### PR DESCRIPTION
## Summary

Fixes the "tık tık" stepping you saw on mobile — the hero now flows like analog film. Three causes, all synchronous work landing mid-loop:

1. **Sprite cache rebuilds (the main tick):** whenever the drifting saturation moved past a threshold, all 72 sprites were rebuilt synchronously — a blocking hitch every few seconds. Sprites are now built **once at init**; saturation drift is applied at composite time via a GPU `ctx.filter = saturate(…)` on the single layer draw (graceful fallback on older Safari: stay fully saturated). Zero mid-animation rebuilds, and saturation is now continuous instead of stepping every 0.06.
2. **Focus tier pops:** 3 discrete softness sprites made dots visibly pop when crossing tiers. Now **6 tiers** with a continuously morphing gradient — crossings are invisible.
3. **Phantom mobile resizes:** phones fire `resize` when the URL bar collapses during scroll, which triggered a full grid rebuild (`getImageData`) with no real size change. Now rebuilds only when the hero's dimensions actually moved.

## Verification
- `npm run build` passes; no stale references.
- Frame-interval measurement over 6 s on a 390 px @2× viewport: **60 fps, p95 = 17 ms, max = 33 ms, zero hitches > 34 ms** — previously the rebuild produced periodic spikes.
- Mobile frame renders correctly (bokeh + crisp dots, MLKFS readable), no JS errors.

https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R

---
_Generated by [Claude Code](https://claude.ai/code/session_018ditHamejvSA4F5iBbnq1R)_