### PR TITLE
feat: launch MLKFS Ideas with library AI essay

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
+  site: 'https://mlkfs.com',
   vite: {
     plugins: [tailwindcss()]
   }

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,6 +2,7 @@
 const links = [
   { href: '/services', label: 'Services' },
   { href: '/software', label: 'Software' },
+  { href: '/blog',     label: 'Ideas' },
   { href: '/about',     label: 'About' },
   { href: '/contact',   label: 'Contact' },
 ];

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,16 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    subtitle: z.string().optional(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    author: z.string(),
+    organization: z.string().default("MLKFS"),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/the-library-should-own-its-intelligence.md
+++ b/src/content/blog/the-library-should-own-its-intelligence.md
@@ -1,0 +1,558 @@
+---
+title: "The Library Should Own Its Intelligence"
+subtitle: "A case for local-first, multilingual and federated AI as public knowledge infrastructure"
+description: "A proposal for local-first, multilingual and federated AI infrastructure that allows libraries to preserve knowledge, protect reading privacy and help researchers navigate ideas across languages and institutions."
+pubDate: 2026-08-14
+author: "Ege Batuhan Akgül"
+organization: "MLKFS"
+---
+
+Libraries have always been more than buildings that store books.
+
+They are systems for preserving memory, organizing knowledge, protecting intellectual freedom and making information available to people who would otherwise have no access to it.
+
+Artificial intelligence does not diminish that role.
+
+It may make it considerably more important.
+
+The question facing libraries is therefore not simply whether they should use AI. It is whether they should allow another generation of information infrastructure to be built entirely outside their control.
+
+The American Library Association's newly adopted guidance on artificial intelligence already places public purpose, privacy, human judgment and institutional responsibility at the center of this discussion. It asks libraries to evaluate AI not merely as software, but against professional values, community needs and public trust. (Ala)
+
+That is a necessary beginning.
+
+But there is a larger possibility.
+
+Libraries should not merely become customers of artificial intelligence. They could become part of the public infrastructure on which trustworthy artificial intelligence is built.
+
+---
+
+## 1. The source must remain human
+
+The first principle should be simple:
+
+> The original work remains the source of truth.
+
+An AI-generated summary is not the book.
+
+A translation is not the original text.
+
+An embedding is not an argument.
+
+A generated answer is not a citation.
+
+AI can create extraordinarily useful representations of human knowledge, but those representations should always lead back to the unchanged human source from which they were derived.
+
+This distinction matters because AI systems make it easy to confuse access to knowledge with possession of truth.
+
+The purpose of a library AI system should not be to replace the document with an answer.
+
+It should be to help a person find the document, understand why it matters, discover its relationship to other documents and decide what to read next.
+
+In this model, AI is not the author of the library.
+
+It is an interface to it.
+
+---
+
+## 2. Preserve once, represent many times
+
+Digitization should become one of the foundations of the AI-era library.
+
+Books, theses, newspapers, manuscripts, photographs, journals and institutional records can be preserved digitally at high archival quality.
+
+But the archival copy does not have to be the form used for every computational task.
+
+One work can have several representations:
+
+**Archival master**\
+The highest-quality preserved version.
+
+**Machine-readable text**\
+OCR or born-digital text suitable for search and accessibility.
+
+**Metadata**\
+Authorship, publication, subjects, dates, citations, rights status and provenance.
+
+**Semantic representation**\
+Indexes or embeddings allowing conceptual rather than purely lexical discovery.
+
+**Summaries**\
+Different levels of abstraction for rapid research and navigation.
+
+**Translations**\
+Machine-generated access layers for readers who do not speak the source language.
+
+This produces an important separation between preservation and computation.
+
+The full-resolution archive remains intact. Smaller derived representations can be replicated cheaply across institutions, searched rapidly and used as part of local AI systems.
+
+A library therefore does not need to choose between keeping the original and making knowledge computationally useful.
+
+It should do both.
+
+---
+
+## 3. Reading privacy should become prompt privacy
+
+For centuries, libraries have defended the idea that what a person reads is a private matter.
+
+AI introduces a new version of the same problem.
+
+A search query can reveal curiosity.
+
+A prompt can reveal an unfinished hypothesis.
+
+A sequence of questions can reveal political interests, medical concerns, religious inquiry, research direction or an idea that has not yet been published.
+
+Sending every interaction to an external AI provider therefore creates a privacy problem that is deeper than ordinary analytics.
+
+The ALA's 2026 guidance explicitly treats AI systems, vendor integrations, privacy and institutional responsibility as library governance issues rather than merely technical decisions. (Ala)
+
+A stronger architectural response is possible:
+
+> Do not send the query away in the first place.
+
+A local-first library AI system could process sensitive searches on hardware operated by the institution or by a trusted library consortium.
+
+The point is not that every model must be open source.
+
+Nor must every component be proprietary.
+
+The more useful distinction is:
+
+Who controls the system?\
+Who controls the corpus?\
+Who can observe the questions?\
+Who can change the rules?\
+And can the library continue operating without the vendor?
+
+A university may choose open models, proprietary models or a combination of both.
+
+What matters is institutional sovereignty over the knowledge system.
+
+---
+
+## 4. Translation could turn the library into a multilingual institution
+
+AI translation changes the economics of access to written knowledge.
+
+Historically, translation has been expensive enough that only a small fraction of the world's books, scholarship and archival material could be made available across languages.
+
+Machine translation cannot replace literary translators, subject experts or authoritative editions.
+
+But it does not have to.
+
+Its first role can be discovery.
+
+Imagine a researcher searching in Turkish and finding relevant material written in Japanese, Spanish, Arabic, Finnish and Portuguese — including works that have never been commercially translated into Turkish.
+
+The system could provide:
+
+* translated titles and metadata,
+* short machine-generated summaries,
+* translated abstracts or previews where rights permit,
+* important concepts and keywords,
+* passages suitable for discovery where legally permitted,
+* and an immediate route back to the original source.
+
+AI translation is already capable of useful work on scientific and technical material; WIPO, for example, operates its own neural machine-translation system for patents and scientific texts across numerous languages. (Dünya Fikri Mülkiyet Örgütü)
+
+Libraries could take the idea further.
+
+Instead of translating every complete work in advance, they could build a multilingual knowledge index.
+
+Each document might produce a compact, structured description that can be searched across many languages.
+
+A Persian paper could become discoverable to a Polish researcher.
+
+A Turkish thesis could appear in the search space of a Brazilian student.
+
+A Japanese monograph could be identified by an American researcher before anyone commits the time or money required for a professional translation.
+
+For low-resource languages, quality will remain uneven and uncertainty must be visible. Important passages may still require human translation.
+
+But the principle is transformative:
+
+> Language should become less of a barrier to discovering that knowledge exists.
+
+And because translation can happen locally, a user's reading interests do not have to become another company's dataset.
+
+---
+
+## 5. We do not need one global library database
+
+Libraries already cooperate.
+
+AI makes a much deeper form of cooperation possible.
+
+A future library network could be federated rather than centralized.
+
+Each institution could retain custody of its own collection while exposing a controlled knowledge layer to other participating libraries.
+
+A query could travel through the network and discover:
+
+This university holds the relevant thesis.
+
+That national library has the archival scan.
+
+Another institution has licensed digital access.
+
+This edition is public domain.
+
+This work may be searched but not reproduced.
+
+That document is available for interlibrary lending.
+
+The network would not require every institution to surrender its archive to one company or one central server.
+
+It would require standards.
+
+Common metadata.
+
+Rights information.
+
+Machine-readable permissions.
+
+Provenance.
+
+Interoperable search.
+
+And a shared understanding that access to knowledge is infrastructure.
+
+Digital lending could eventually become part of this architecture, but lending, indexing, summarization, computational analysis, translation and model training should not be treated as legally identical actions.
+
+The technical system should understand those distinctions.
+
+---
+
+## 6. Copyright should be part of the architecture
+
+AI and copyright are often discussed as though there are only two possible positions:
+
+Everything should be freely ingested.
+
+Or nothing copyrighted should be computationally processed.
+
+A library system can be more precise.
+
+Every work could carry a machine-readable rights state.
+
+For example:
+
+**Public domain**\
+Broad preservation, computation and access.
+
+**Openly licensed**\
+Use according to the stated license.
+
+**Institutionally licensed**\
+Use within negotiated permissions.
+
+**Research-access material**\
+Computational analysis subject to applicable law and institutional policy.
+
+**Restricted works**\
+Limited operations such as metadata discovery.
+
+**Unknown rights**\
+Preserve cautiously and restrict automated downstream use until reviewed.
+
+This is important because "AI use" is itself not one action.
+
+Pre-training a model, building a search index, generating embeddings, performing text-and-data analysis, using retrieval-augmented generation and displaying passages to users are technically and legally different activities.
+
+The U.S. Copyright Office has itself emphasized that different uses of copyrighted material during AI development and deployment may require separate analysis, specifically distinguishing initial training from later uses such as RAG. (Telif Hakkı Ofisi)
+
+Its 2025 report also describes a spectrum rather than a universal rule: some noncommercial research or analytical uses may weigh differently from systems built from unlawfully obtained material to generate substitutive commercial content. (Telif Hakkı Ofisi)
+
+That uncertainty is not a reason for libraries to avoid the field.
+
+It is a reason to build systems where provenance and permissions are visible from the beginning.
+
+A trustworthy knowledge system should know not only what a document says, but where it came from and what may legally be done with it.
+
+---
+
+## 7. Search is more interesting than generation
+
+The most consequential library AI may not be a chatbot.
+
+It may be a new kind of search engine.
+
+Current library search largely asks:
+
+Which documents match these words, subjects or citations?
+
+Semantic systems make more difficult questions possible:
+
+Where else has this idea appeared?
+
+Which disciplines describe the same phenomenon with different terminology?
+
+Which papers disagree with this assumption?
+
+What earlier work most closely resembles this hypothesis?
+
+Which research communities appear to have independently reached related conclusions?
+
+What changed in the literature after a particular discovery?
+
+This changes the library from a catalogue of objects into a map of ideas.
+
+A researcher should be able to enter not only a keyword, but a proposition.
+
+The system could then search millions of pages for conceptual relatives, contradictions, precursors and unexplored combinations.
+
+And unlike a general web chatbot, a library system could show its work.
+
+Every conclusion could point back to specific sources.
+
+---
+
+## 8. Can AI help us identify what is actually new?
+
+This may be the more interesting question.
+
+Scientific and intellectual progress depends partly on knowing what humanity already knows.
+
+But that task becomes harder every year.
+
+No researcher can read every relevant paper.
+
+No philosopher can compare every argument written across every language.
+
+No interdisciplinary team can manually map the complete literature of every neighboring field.
+
+AI may be able to help.
+
+Not by declaring:
+
+> "This idea is new."
+
+That claim would be too strong.
+
+But by answering a narrower and more defensible question:
+
+> "Within the corpus we can search, how closely has this idea appeared before?"
+
+A system could construct a map around a proposed hypothesis:
+
+closest conceptual predecessors,
+
+contradictory evidence,
+
+similar arguments under different vocabulary,
+
+forgotten research,
+
+new evidence affecting old theories,
+
+and connections between literatures that rarely cite each other.
+
+Eventually, such systems may become useful not only for retrieving established knowledge, but for identifying gaps in the structure of knowledge itself.
+
+Two ideas may already exist independently but never have been connected.
+
+A prediction may have been ignored because the evidence required to test it did not yet exist.
+
+A minor thesis from decades ago may become unexpectedly relevant after a technological change.
+
+The library could become a machine for detecting these possibilities.
+
+But the machine should never become the final judge.
+
+AI can identify where to look. Humans must still decide what something means.
+
+---
+
+## 9. The multilingual index may be more valuable than the universal model
+
+There is a tendency to imagine the future of AI as one increasingly enormous model containing everything.
+
+Libraries suggest another architecture.
+
+We may not need one machine that has absorbed every book.
+
+We may need a reliable index of human knowledge that many machines can consult.
+
+Such an index could contain compact multilingual representations of works while preserving the originals separately.
+
+A researcher could navigate human knowledge at very low computational cost and retrieve the full source only when necessary.
+
+This also creates a healthier relationship between the AI and the archive.
+
+The model does not have to pretend that it contains the library.
+
+It knows how to ask the library.
+
+That distinction may prove fundamental.
+
+---
+
+## 10. Libraries could build the legitimate knowledge commons AI needs
+
+The present AI economy has produced a strange conflict.
+
+Human knowledge is extraordinarily valuable for training intelligent systems, but the rights, provenance and consent surrounding enormous datasets are often disputed.
+
+Libraries are unusually well positioned to build something better.
+
+Universities, authors, public institutions, researchers and open-access publishers could contribute works to a deliberately constructed computational knowledge commons.
+
+Public-domain material could enter automatically.
+
+Creative Commons and open-access works could carry explicit machine-readable permissions.
+
+Authors could choose whether their work may be indexed, translated, summarized, used for research, retrieved by models or included in particular forms of training.
+
+Instead of the provenance of an AI corpus being unknowable, it could become one of its most important properties.
+
+This would not eliminate the conflict between copyright and machine learning.
+
+It would create an alternative to pretending that the conflict does not exist.
+
+---
+
+## 11. A possible architecture
+
+The idea does not require a single product or a single model.
+
+A practical system could have several layers:
+
+### Preservation layer
+
+Immutable archival copies, distributed backups and preservation metadata.
+
+### Rights layer
+
+Licenses, public-domain status, access controls and machine-readable permissions.
+
+### Text layer
+
+OCR, structured text, citations and document metadata.
+
+### Semantic layer
+
+Embeddings, entity relationships, concepts and cross-document links.
+
+### Language layer
+
+Multilingual summaries, terminology mappings and on-demand translation.
+
+### Retrieval layer
+
+Local search, semantic search and source-grounded AI retrieval.
+
+### Federation layer
+
+Secure discovery and permission-aware exchange between participating libraries.
+
+### Intelligence layer
+
+Tools for literature mapping, contradiction detection, hypothesis comparison and research discovery.
+
+### Human layer
+
+Librarians, researchers, translators, authors and readers retaining authority over interpretation.
+
+The last layer is the most important one.
+
+---
+
+## 12. The goal is not an autonomous library
+
+The strongest AI library is not a library without librarians.
+
+It is a library in which librarians can operate at a larger intellectual scale.
+
+The system can search a billion relationships.
+
+The librarian can understand why the question matters.
+
+The system can generate twenty translations.
+
+A translator can determine whether one is faithful.
+
+The system can find a hundred related papers.
+
+A researcher can determine which evidence survives scrutiny.
+
+The system can propose that an idea appears novel.
+
+A scholar can discover that the system misunderstood the idea entirely.
+
+Human fallibility does not justify replacing humans with machines.
+
+Machine fallibility does not justify refusing machines.
+
+They have different strengths.
+
+The architecture should recognize that.
+
+---
+
+## The library after AI
+
+The history of the library is partly a history of compression.
+
+Oral memory became writing.
+
+Scrolls became codices.
+
+Manuscripts became printed books.
+
+Catalogues became databases.
+
+Physical indexes became digital search.
+
+Each transition changed how much knowledge a person could reach without eliminating the value of the original work.
+
+Artificial intelligence may represent another such transition.
+
+But there is an important choice to make.
+
+The new interface to human knowledge can be controlled primarily by a few remote platforms whose incentives, datasets and internal decisions are invisible to the institutions depending on them.
+
+Or libraries, universities and public institutions can participate in building another model:
+
+local where privacy demands it,
+
+federated where cooperation improves it,
+
+multilingual where language divides knowledge,
+
+open where rights permit it,
+
+restricted where rights require it,
+
+source-grounded rather than source-replacing,
+
+and always designed so that a generated answer can lead a person back to the work of another human being.
+
+The future library should not attempt to become an oracle.
+
+It should become something more useful:
+
+a map of what humanity has thought,\
+a memory of where those thoughts came from,\
+and an instrument for discovering where we might think next.
+
+AI should help us navigate that map.
+
+It should never become the map itself.
+
+---
+
+## Working principles
+
+1. The original source remains canonical.
+2. Preservation comes before optimization.
+3. Sensitive queries should be processed locally whenever practical.
+4. Institutional control matters more than the open-versus-closed-source label.
+5. Machine translation should expand discovery, not silently replace authoritative translation.
+6. Every generated claim should be traceable to human sources.
+7. Copyright status and provenance should be machine-readable parts of the system.
+8. Libraries should federate rather than surrender their collections to a single platform.
+9. AI should help assess novelty, contradiction and relationships—not declare intellectual truth.
+10. Human judgment remains the final layer of the knowledge system.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,10 +3,22 @@ import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
 import "../styles/global.css";
 
-export interface Props { title?: string; description?: string }
+export interface Props {
+  title?: string;
+  description?: string;
+  canonical?: string;
+  ogType?: string;
+  article?: {
+    publishedTime?: string;
+    author?: string;
+  };
+}
 const {
   title = "MLKFS – Audio-Visual, Software & Creative",
-  description = "MLKFS builds and applies technology across audio-visual, software, and creative work."
+  description = "MLKFS builds and applies technology across audio-visual, software, and creative work.",
+  canonical,
+  ogType = "website",
+  article
 } = Astro.props;
 ---
 <html lang="en" class="h-full bg-white text-black">
@@ -16,6 +28,18 @@ const {
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="icon" href="/favicon.ico" />
+    {canonical && <link rel="canonical" href={canonical} />}
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content={ogType} />
+    {canonical && <meta property="og:url" content={canonical} />}
+    <meta property="og:site_name" content="MLKFS" />
+    {article?.publishedTime && <meta property="article:published_time" content={article.publishedTime} />}
+    {article?.author && <meta property="article:author" content={article.author} />}
+    {article?.author && <meta name="author" content={article.author} />}
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
   </head>
 
   <body class="min-h-screen flex flex-col bg-white">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,139 @@
+---
+import { getCollection, render } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const title = `${post.data.title} – ${post.data.organization}`;
+const canonical = new URL(`/blog/${post.id}`, Astro.site).href;
+const pubDateISO = post.data.pubDate.toISOString().slice(0, 10);
+const pubDateHuman = post.data.pubDate.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<BaseLayout
+  {title}
+  description={post.data.description}
+  {canonical}
+  ogType="article"
+  article={{ publishedTime: pubDateISO, author: post.data.author }}
+>
+  <article class="container-xl pt-28 pb-24">
+    <div class="mx-auto max-w-2xl">
+      <header>
+        <p class="text-sm text-gray-500">
+          <a href="/blog" class="hover:underline underline-offset-4">Ideas</a>
+        </p>
+        <h1 class="mt-3 text-4xl md:text-5xl font-bold leading-tight text-black text-balance">
+          {post.data.title}
+        </h1>
+        {post.data.subtitle && (
+          <p class="mt-4 text-lg text-gray-700 leading-relaxed">{post.data.subtitle}</p>
+        )}
+        <p class="mt-6 text-sm text-gray-500">
+          {post.data.author}
+          <span aria-hidden="true"> · </span>
+          {post.data.organization}
+          <span aria-hidden="true"> · </span>
+          <time datetime={pubDateISO}>{pubDateHuman}</time>
+        </p>
+      </header>
+
+      <div class="essay mt-12">
+        <Content />
+      </div>
+
+      <footer class="mt-16 border-t border-black/10 pt-8">
+        <a href="/blog" class="text-sm font-medium text-black hover:underline underline-offset-4">
+          ← All essays
+        </a>
+      </footer>
+    </div>
+  </article>
+</BaseLayout>
+
+<style is:global>
+  .essay {
+    font-size: 1.0625rem;
+    line-height: 1.75;
+    color: #1f2937;
+    max-width: 65ch;
+  }
+  .essay p {
+    margin-top: 1.25em;
+  }
+  .essay h2 {
+    margin-top: 3rem;
+    font-size: 1.5rem;
+    line-height: 1.3;
+    font-weight: 700;
+    color: #000;
+  }
+  .essay h3 {
+    margin-top: 2rem;
+    font-size: 1.125rem;
+    line-height: 1.4;
+    font-weight: 600;
+    color: #000;
+  }
+  .essay blockquote {
+    margin-top: 1.5em;
+    padding-left: 1.25rem;
+    border-left: 2px solid var(--accent);
+    font-weight: 500;
+    color: #000;
+  }
+  .essay blockquote p {
+    margin-top: 0;
+  }
+  .essay ul,
+  .essay ol {
+    margin-top: 1.25em;
+    padding-left: 1.5rem;
+  }
+  .essay ul {
+    list-style: disc;
+  }
+  .essay ol {
+    list-style: decimal;
+  }
+  .essay li {
+    margin-top: 0.5em;
+    padding-left: 0.25rem;
+  }
+  .essay hr {
+    margin-top: 3rem;
+    border: 0;
+    border-top: 1px solid rgb(0 0 0 / 0.1);
+  }
+  .essay a {
+    color: #000;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    text-decoration-color: rgb(0 0 0 / 0.3);
+  }
+  .essay a:hover {
+    text-decoration-color: #000;
+  }
+  .essay strong {
+    color: #000;
+  }
+  @media (max-width: 640px) {
+    .essay {
+      font-size: 1rem;
+    }
+  }
+</style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,55 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+
+const title = "Ideas – MLKFS";
+const description = "Essays and working notes from MLKFS on technology, knowledge infrastructure and creative work.";
+const canonical = new URL("/blog", Astro.site).href;
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" });
+---
+
+<BaseLayout {title} {description} {canonical}>
+  <section class="container-xl pt-28 pb-24">
+    <div class="mx-auto max-w-3xl">
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight text-black">Ideas</h1>
+      <p class="mt-4 text-base text-gray-700 leading-relaxed">
+        Essays and working notes from MLKFS.
+      </p>
+
+      <ul class="mt-12 space-y-10">
+        {posts.map((post) => (
+          <li class="border-t border-black/10 pt-8">
+            <article>
+              <p class="text-sm text-gray-500">
+                <time datetime={post.data.pubDate.toISOString().slice(0, 10)}>
+                  {formatDate(post.data.pubDate)}
+                </time>
+                <span aria-hidden="true"> · </span>
+                {post.data.author}
+              </p>
+              <h2 class="mt-2 text-2xl font-bold text-black leading-snug">
+                <a href={`/blog/${post.id}`} class="hover:underline underline-offset-4">
+                  {post.data.title}
+                </a>
+              </h2>
+              {post.data.subtitle && (
+                <p class="mt-2 text-base text-gray-700 leading-relaxed">{post.data.subtitle}</p>
+              )}
+              <p class="mt-3">
+                <a href={`/blog/${post.id}`} class="text-sm font-medium text-black hover:underline underline-offset-4">
+                  Read the essay →
+                </a>
+              </p>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Launches a maintainable blog / Ideas section on mlkfs.com and publishes the first essay, **“The Library Should Own Its Intelligence”** by Ege Batuhan Akgül (August 14, 2026). The article text is published verbatim as supplied — no rewriting or summarizing.

## What's new

- **Content collection** — `src/content.config.ts` defines a `blog` collection (Astro 5 glob loader) with a schema for `title`, `subtitle`, `description`, `pubDate`, `author`, `organization`. Future essays are just new `.md` files in `src/content/blog/`.
- **Essay content** — `src/content/blog/the-library-should-own-its-intelligence.md` (the article lives as Markdown, not hard-coded in a template).
- **`/blog` landing page** — `src/pages/blog/index.astro` lists essays with title, subtitle, date and author, sorted newest-first.
- **`/blog/[...slug]` essay page** — whitepaper-style typography scoped to an `.essay` class: ~65ch measure, generous leading, semantic H1→H2→H3 hierarchy, real blockquotes, hr section breaks, citrus-accented quote rules matching the existing brand accent.
- **SEO** — `BaseLayout` extended (backwards-compatibly) with canonical URL, Open Graph (`og:type: article`, `article:published_time`, `article:author`) and Twitter card tags; `site: 'https://mlkfs.com'` added to `astro.config.mjs`. Canonical: `https://mlkfs.com/blog/the-library-should-own-its-intelligence`.
- **Navigation** — “Ideas” added to the shared links array in `Navbar.astro`, so it appears in both desktop and mobile menus with no changes to the menu behavior.

## Verification

- `npm ci && npm run build` passes; 12 pages built.
- Generated routes include `/blog/index.html` and `/blog/the-library-should-own-its-intelligence/index.html`; all pre-existing pages still build unchanged.
- Verified the rendered HTML has a single H1, 14 H2s, 9 H3s, blockquotes, and complete canonical/OG/Twitter/article metadata.
- No changes to CNAME, `apps/`, deployment workflow, or existing pages other than the shared layout/nav extensions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCUVDosFax8PkfGXkuegkv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCUVDosFax8PkfGXkuegkv)_